### PR TITLE
Add nginx reverse proxy setup to connect frontend and backend

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,16 @@
 services:
+  reverse-proxy:
+    # proxy outside requests to internal services
+    image: nginx:stable
+    container_name: reverse_proxy
+    depends_on:
+      - database
+      - backend
+      - frontend
+    volumes:
+      - ./reverseProxy/nginx.conf:/etc/nginx/nginx.conf
+    ports:
+      - 8080:8080
   database:
     container_name: urlShortener
     image: postgres # https://hub.docker.com/_/postgres
@@ -24,8 +36,7 @@ services:
       - ./backend:/usr/url-shorten/backend
     ports:
       # Map outsidePort:insidePort, making request to outsidePort will call container insidePort
-      # e.g. if backend is listening on port 3000, => <somePort>:3000
-      - 13000:3000
+      - 3000:3000
     depends_on:
       database:
         condition: service_healthy

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,9 @@
 FROM node:22
 WORKDIR /usr/url-shorten/frontend
 
-COPY . .
+COPY package*.json ./
 RUN npm install
+COPY . .
 RUN npm run build
 
 EXPOSE 5173

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>URL Shortener</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/components/ShortUrlForm.tsx
+++ b/frontend/src/components/ShortUrlForm.tsx
@@ -12,8 +12,11 @@ function ShortUrlForm() {
     formState: { errors },
   } = useForm<FormFields>()
   const onSubmit: SubmitHandler<FormFields> = async (data) => {
-    // TODO call backend to get short url
+    // TODO call backend to get short url using relative path "/api"
     console.log(data)
+    // const response = await fetch("/api/shorten/CaOdHlM")
+    // const json = await response.json()
+    // console.log(JSON.stringify(json))
   }
   function isValidUrl(value: string) {
     const errorMessage =

--- a/reverseProxy/README.md
+++ b/reverseProxy/README.md
@@ -21,3 +21,19 @@ If you do this, then e.g. http://localhost:8900 is the front-end and http://loca
 ```
 
 - Docker and Nginx Reverse Proxy - https://www.youtube.com/watch?v=hxngRDmHTM0
+
+- How to Fix WebSocket Connection Error in Nginx and React on Docker - https://dev.to/ndohjapan/how-to-fix-websocket-connection-error-in-nginx-and-react-on-docker-3405
+
+  - Web app is trying to access ws://localhost:3000/ws, which does not exist, and Nginx is running on a different port.
+  - Add the location /ws into the Nginx configuration file and route it to the React client running in the Docker container.
+
+  ```
+  location /ws {
+    proxy_pass http://localhost:3000;
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "Upgrade";
+  }
+  ```
+
+  The location block defines the URL path that should be routed to the React app running on port 3000. The proxy_pass directive sets the URL to which the request should be forwarded, and the proxy_http_version and proxy_set_header directives configure the connection between Nginx and the React app.

--- a/reverseProxy/README.md
+++ b/reverseProxy/README.md
@@ -1,0 +1,23 @@
+# Reverse Proxy
+
+Web container cannot call backend container from docker compose - https://stackoverflow.com/questions/60986908/web-container-cannot-call-backend-container-from-docker-compose
+
+- David Maze
+
+```
+The important thing for this setup is that your actual front-end code is not running in Docker, it's running in your browser. That means it has no idea about Docker networking, containers, or anything else; the URL you give it has to be one that reaches a published port on your host. That's why localhost works here (if the browser and containers are running on the same host) but backend doesn't.
+
+A typical approach to this is to set up some sort of reverse proxy that can both host the front-end application code and proxy to the back-end application. (For example, set up Nginx where its /api route proxy_pass http://backend:8098, and its / route either try_files a prebuilt Javascript application or proxy_pass http://frontend:8080.)
+
+If you do this, then e.g. http://localhost:8900 is the front-end and http://localhost:8900/api is the back-end, from the browser's point of view. This avoids the CORS issues @coedycode hints at in their answer; but it also means that the front-end code can use a relative URL /api (with no host name) and dodge this whole problem.
+
++-------------+                  | Docker >           /     +----------+
++-------------+                  |                 /------> | frontend |
+|             |  localhost:8900  |    +-------+    |        +----------+
+|   Browser   | ---------------> | -> | nginx | -> +
+|             |                  |    +-------+    | /api   +----------+
+|             |                  |                 \------> | backend  |
++-------------+                  |                          +----------+
+```
+
+- Docker and Nginx Reverse Proxy - https://www.youtube.com/watch?v=hxngRDmHTM0

--- a/reverseProxy/nginx.conf
+++ b/reverseProxy/nginx.conf
@@ -19,5 +19,14 @@ http {
       proxy_pass http://backend:3000;
       proxy_set_header Forwarded $remote_addr;
     }
+
+    # https://github.com/gradio-app/gradio/issues/4493
+    # https://dev.to/ndohjapan/how-to-fix-websocket-connection-error-in-nginx-and-react-on-docker-3405
+    location /ws {
+      proxy_pass http://localhost:3000;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "Upgrade";
+    }
   }
 }

--- a/reverseProxy/nginx.conf
+++ b/reverseProxy/nginx.conf
@@ -1,0 +1,23 @@
+worker_processes auto;
+error_log /var/log/nginx/error.log;
+
+events {}
+
+http {
+  # reverse proxy
+  server {
+    listen 8080;
+    server_name localhost 127.0.0.1;
+
+    location / {
+      # use docker compose created network to access service name
+      proxy_pass http://frontend:5173/;
+      proxy_set_header Forwarded $remote_addr;
+    }
+
+    location ~ /api/ {
+      proxy_pass http://backend:3000;
+      proxy_set_header Forwarded $remote_addr;
+    }
+  }
+}


### PR DESCRIPTION
Docker and Nginx Reverse Proxy - https://www.youtube.com/watch?v=hxngRDmHTM0

Web container cannot call backend container from docker compose - https://stackoverflow.com/questions/60986908/web-container-cannot-call-backend-container-from-docker-compose

  - [David Maze](https://stackoverflow.com/users/10008173/david-maze)
  - The important thing for this setup is that your actual front-end code is not running in Docker, it's running in your browser. That means it has no idea about Docker networking, containers, or anything else; the URL you give it has to be one that reaches a published port on your host. That's why localhost works here (if the browser and containers are running on the same host) but backend doesn't
  - A typical approach to this is to set up some sort of reverse proxy that can both host the front-end application code and proxy to the back-end application. (For example, set up Nginx where its /api route proxy_pass http://backend:8098, and its / route either try_files a prebuilt Javascript application or proxy_pass http://frontend:8080.)
  - If you do this, then e.g. `http://localhost:8900` is the front-end and `http://localhost:8900/api` is the back-end, from the browser's point of view. This avoids the CORS issues @coedycode hints at in [their answer](https://stackoverflow.com/a/60988610/10008173); but it also means that the front-end code can use a relative URL /api (with no host name) and dodge this whole problem.

```
+-------------+                  | Docker >           /     +----------+
+-------------+                  |                 /------> | frontend |
|             |  localhost:8900  |    +-------+    |        +----------+
|   Browser   | ---------------> | -> | nginx | -> +
|             |                  |    +-------+    | /api   +----------+
|             |                  |                 \------> | backend  |
+-------------+                  |                          +----------+
```

How to Fix WebSocket Connection Error in Nginx and React on Docker - https://dev.to/ndohjapan/how-to-fix-websocket-connection-error-in-nginx-and-react-on-docker-3405

  - Web app is trying to access ws://localhost:3000/ws, which does not exist, and Nginx is running on a different port.
  - Add the location /ws into the Nginx configuration file and route it to the React client running in the Docker container.

  ```
  location /ws {
    proxy_pass http://localhost:3000;
    proxy_http_version 1.1;
    proxy_set_header Upgrade $http_upgrade;
    proxy_set_header Connection "Upgrade";
  }
  ```

  The location block defines the URL path that should be routed to the React app running on port 3000. The proxy_pass directive sets the URL to which the request should be forwarded, and the proxy_http_version and proxy_set_header directives configure the connection between Nginx and the React app.
