### PR TITLE
Add backend rate limit and frontend error message display for rate limit exceeded

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,8 +1,11 @@
 # Backend for url shortener
 
 Made using TypeScript, Express, PostgreSQL, `nanoid` package to generate shortUrl.
+
 `express-validator` package for validating requests using schemas
 Run using Docker
+
+`express-rate-limit` package to rate limit API endpoints (https://www.npmjs.com/package/express-rate-limit)
 
 Structure backend using Controller and Model (MV in MVC pattern - https://www.youtube.com/watch?v=DUg2SWWK18I)
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "express": "4.21.0",
+        "express-rate-limit": "7.4.1",
         "express-validator": "7.2.0",
         "nanoid": "5.0.7",
         "pg": "8.13.0"
@@ -600,6 +601,21 @@
       },
       "engines": {
         "node": ">= 0.10.0"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.4.1.tgz",
+      "integrity": "sha512-KS3efpnpIDVIXopMc65EMbWbUht7qvTCdtCR2dD/IZmi9MIkopYESwyRqLgv8Pfu589+KqDqOdzJWW7AHoACeg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "4 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/express-validator": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
   "description": "",
   "dependencies": {
     "express": "4.21.0",
+    "express-rate-limit": "7.4.1",
     "express-validator": "7.2.0",
     "nanoid": "5.0.7",
     "pg": "8.13.0"

--- a/backend/route/shorten.ts
+++ b/backend/route/shorten.ts
@@ -30,9 +30,16 @@ const readLimiter = rateLimit({
     res.status(options.statusCode).send(options.message)
   },
 })
+const createLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 2,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+})
 
 router.post(
   "/api/shorten",
+  createLimiter,
   checkSchema(createUrlValidationSchema(), ["body"]),
   async (req: Request, res: Response) => {
     const errors = validationResult(req)

--- a/backend/route/shorten.ts
+++ b/backend/route/shorten.ts
@@ -36,6 +36,18 @@ const createLimiter = rateLimit({
   standardHeaders: "draft-7",
   legacyHeaders: false,
 })
+const updateLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 1,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+})
+const deleteLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  limit: 1,
+  standardHeaders: "draft-7",
+  legacyHeaders: false,
+})
 
 router.post(
   "/api/shorten",
@@ -87,6 +99,7 @@ router.get(
 
 router.put(
   "/api/shorten/:shortCode",
+  updateLimiter,
   checkSchema(createShortCodeValidationSchema(), ["params"]),
   async (req: Request, res: Response) => {
     const errors = validationResult(req)
@@ -115,6 +128,7 @@ router.put(
 
 router.delete(
   "/api/shorten/:shortCode",
+  deleteLimiter,
   checkSchema(createShortCodeValidationSchema(), ["params"]),
   async (req: Request, res: Response) => {
     const errors = validationResult(req)

--- a/frontend/src/components/ShortUrl.css
+++ b/frontend/src/components/ShortUrl.css
@@ -8,9 +8,11 @@
   box-shadow: rgba(100, 100, 111, 0.2) 0px 7px 29px 0px;
 }
 
-.card p {
+.card p,
+.card a {
   text-wrap: wrap;
   word-wrap: break-all;
+  overflow-wrap: break-word;
 }
 
 .text-center {

--- a/frontend/src/components/ShortUrlForm.tsx
+++ b/frontend/src/components/ShortUrlForm.tsx
@@ -23,8 +23,9 @@ function ShortUrlForm({
       handleCreateUrl(json)
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (error: any) {
-      console.error(error.message)
-      setError("root", { message: "Could not create short url" })
+      setError("root", {
+        message: `Could not create short url. ${error.message}`,
+      })
     }
   }
   function isValidUrl(value: string) {

--- a/frontend/src/endpoints/createUrl.ts
+++ b/frontend/src/endpoints/createUrl.ts
@@ -11,6 +11,7 @@ interface Url {
 async function createNewUrl(url: string): Promise<Url> {
   const response = await ky.post("/api/shorten", {
     json: { url },
+    retry: { limit: 0 },
   })
   if (!response.ok || response.status !== 201) {
     throw new Error("Could not create short url")

--- a/frontend/src/endpoints/createUrl.ts
+++ b/frontend/src/endpoints/createUrl.ts
@@ -9,14 +9,25 @@ interface Url {
 }
 
 async function createNewUrl(url: string): Promise<Url> {
-  const response = await ky.post("/api/shorten", {
-    json: { url },
-    retry: { limit: 0 },
-  })
-  if (!response.ok || response.status !== 201) {
-    throw new Error("Could not create short url")
+  try {
+    const response = await ky.post("/api/shorten", {
+      json: { url },
+      retry: { limit: 0 },
+    })
+    if (!response.ok || response.status !== 201) {
+      throw new Error("Could not create short url")
+    }
+    return await response.json()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } catch (error: any) {
+    if (error.response.status === 429) {
+      const timeoutInSeconds = error.response.headers.get("retry-after")
+      throw new Error(
+        `Rate Limit Exceeded, please try again after ${timeoutInSeconds} seconds`
+      )
+    }
+    throw error
   }
-  return await response.json()
 }
 
 export type { Url }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -12,18 +12,26 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: <App />,
-    errorElement: <NotFoundPage />,
+    errorElement: <NotFoundPage errorMessage="404 Not Found" />,
+  },
+  {
+    path: "/error/too-many-requests",
+    element: <NotFoundPage errorMessage="429 Too Many Requests" />,
+  },
+  {
+    path: "/error",
+    element: <NotFoundPage errorMessage="404 Not Found" />,
   },
   {
     path: "/:shortCode",
     element: <RedirectUrlPage />,
     loader: redirectLoader,
-    errorElement: <NotFoundPage />,
+    errorElement: <NotFoundPage errorMessage="404 Not Found" />,
   },
   {
     path: "/stats",
     element: <UrlStatsPage />,
-    errorElement: <NotFoundPage />,
+    errorElement: <NotFoundPage errorMessage="404 Not Found" />,
   },
 ])
 

--- a/frontend/src/pages/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage.tsx
@@ -1,10 +1,10 @@
 import { Link } from "react-router-dom"
 import "./NotFoundPage.css"
 
-function NotFoundPage() {
+function NotFoundPage({ errorMessage }: { errorMessage: string }) {
   return (
     <div className="not-found-container">
-      <h1 className="not-found-title">Error - 404</h1>
+      <h1 className="not-found-title">Error - {errorMessage}</h1>
       <div className="not-found-content">
         <p>An error has occured, to continue:</p>
         <p>* Return to the homepage.</p>


### PR DESCRIPTION
Add rate limit to backend api using package `express-rate-limit`  - https://www.npmjs.com/package/express-rate-limit

Add frontend error message when rate limit is exceeded

Show frontend `/error/too-many-requests` 429 page when rate limit is exceeded (read request for short url)

Remove `ky` HTTP retry (set to zero retry)