### PR TITLE
Add create new account feature

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -29,6 +29,7 @@ Favicon generated from https://favicon.io/emoji-favicons/robot
 4. Data Fetching and Aborting requests - https://www.youtube.com/watch?v=00lxm_doFYw
    - https://github.com/sindresorhus/ky?tab=readme-ov-file#cancellation
 5. Handling React useEffect firing twice due to Strict Mode - https://react.dev/learn/synchronizing-with-effects#how-to-handle-the-effect-firing-twice-in-development
+6. check two TextField have the same value with react-hook-form - https://stackoverflow.com/questions/63096634/check-two-textfield-have-the-same-value-with-react-hook-form
 
 # React + TypeScript + Vite
 

--- a/frontend/__tests__/account.create.spec.ts
+++ b/frontend/__tests__/account.create.spec.ts
@@ -104,7 +104,9 @@ test("submission fails with rate limit exception should display root error messa
 test("password is blank should display password error", async ({ page }) => {
   await page.getByLabel("Password", { exact: true }).clear()
   await page.getByRole("button", { name: "Create Account" }).click()
-  await expect(page.getByText("Password is required")).toBeVisible()
+  await expect(
+    page.getByText("Password is required", { exact: true })
+  ).toBeVisible()
 })
 
 test("invalid password min length should display password error", async ({
@@ -121,5 +123,37 @@ test("invalid password min length should display password error", async ({
   await page.getByLabel("Password", { exact: true }).fill("12345678")
   await expect(
     page.getByText("Password needs to have min length of 8 characters")
+  ).not.toBeVisible()
+})
+
+test("confirm password is blank should display confirm password error", async ({
+  page,
+}) => {
+  await page.getByLabel("Confirm Password").clear()
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(page.getByText("Confirm Password is required")).toBeVisible()
+})
+
+test("confirm password that does not match password displays error", async ({
+  page,
+}) => {
+  await page
+    .getByLabel("Confirm Password", { exact: true })
+    .fill("test_password")
+  await page.getByLabel("Password", { exact: true }).fill("12345678")
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(
+    page.getByText("Password and Confirm Password needs to match", {
+      exact: true,
+    })
+  ).toBeVisible()
+
+  await page.getByLabel("Confirm Password", { exact: true }).fill("test12345")
+  await page.getByLabel("Password", { exact: true }).fill("test12345")
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(
+    page.getByText("Password and Confirm Password needs to match", {
+      exact: true,
+    })
   ).not.toBeVisible()
 })

--- a/frontend/__tests__/account.create.spec.ts
+++ b/frontend/__tests__/account.create.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect, Page } from "@playwright/test"
+import { HOMEPAGE_URL } from "./constants"
+
+async function mockLoginEndpoint(page: Page) {
+  await page.route("*/**/api/auth/users", async (route) => {
+    const request = route.request()
+    expect(request.method()).toBe("POST")
+    await route.fulfill({
+      status: 201,
+      json: "Created",
+    })
+  })
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(HOMEPAGE_URL + "/register")
+  expect(page.url()).toContain("/register")
+})
+
+test("should create new account", async ({ page }) => {
+  await mockLoginEndpoint(page)
+
+  await expect(
+    page.getByRole("heading", { name: "Create a new account" })
+  ).toBeVisible()
+  await expect(page.getByLabel("Username")).toBeVisible()
+  await expect(page.getByLabel("Username")).toHaveAttribute("type", "text")
+  await expect(page.getByLabel("Password", { exact: true })).toBeVisible()
+  await expect(page.getByLabel("Password", { exact: true })).toHaveAttribute(
+    "type",
+    "password"
+  )
+  await expect(page.getByLabel("Confirm Password")).toBeVisible()
+  await expect(page.getByLabel("Confirm Password")).toHaveAttribute(
+    "type",
+    "password"
+  )
+
+  await page.getByLabel("Username").fill("test_username")
+  await page.getByLabel("Password", { exact: true }).fill("test_password")
+  await page.getByLabel("Confirm Password").fill("test_password")
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(
+    page.getByRole("heading", { name: "Login", exact: true })
+  ).toBeVisible()
+  expect(page.url()).toContain("/login")
+})

--- a/frontend/__tests__/account.create.spec.ts
+++ b/frontend/__tests__/account.create.spec.ts
@@ -12,6 +12,21 @@ async function mockLoginEndpoint(page: Page) {
   })
 }
 
+async function mockLoginRateLimitExceededEndpoint(
+  page: Page,
+  timeoutInSeconds: number
+) {
+  await page.route("*/**/api/auth/users", async (route) => {
+    const request = route.request()
+    expect(request.method()).toBe("POST")
+    await route.fulfill({
+      status: 429,
+      headers: { "retry-after": `${timeoutInSeconds}` },
+      json: "Too many requests, please try again later.",
+    })
+  })
+}
+
 test.beforeEach(async ({ page }) => {
   await page.goto(HOMEPAGE_URL + "/register")
   expect(page.url()).toContain("/register")
@@ -44,4 +59,44 @@ test("should create new account", async ({ page }) => {
     page.getByRole("heading", { name: "Login", exact: true })
   ).toBeVisible()
   expect(page.url()).toContain("/login")
+})
+
+test("should display error when username is blank", async ({ page }) => {
+  await page.getByLabel("Username").clear()
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(page.getByText("Username is required")).toBeVisible()
+})
+
+test("should display error when username is more than 255 characters", async ({
+  page,
+}) => {
+  const username = "a".repeat(256)
+  await page.getByLabel("Username").fill(username)
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(
+    page.getByText("Username cannot be longer than 255 characters")
+  ).toBeVisible()
+
+  await page.getByLabel("Username").clear()
+  await page.getByLabel("Username").fill("b".repeat(255))
+  await expect(
+    page.getByText("Username cannot be longer than 255 characters")
+  ).not.toBeVisible()
+})
+
+test("should display root error message when submission fails with rate limit exception", async ({
+  page,
+}) => {
+  const timeoutInSeconds = 30
+  await mockLoginRateLimitExceededEndpoint(page, timeoutInSeconds)
+
+  await page.getByLabel("Username").fill("test_username")
+  await page.getByLabel("Password", { exact: true }).fill("test_password")
+  await page.getByLabel("Confirm Password").fill("test_password")
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(
+    page.getByText(
+      `Rate Limit Exceeded, please try again after ${timeoutInSeconds} seconds`
+    )
+  ).toBeVisible()
 })

--- a/frontend/__tests__/account.create.spec.ts
+++ b/frontend/__tests__/account.create.spec.ts
@@ -61,13 +61,13 @@ test("should create new account", async ({ page }) => {
   expect(page.url()).toContain("/login")
 })
 
-test("should display error when username is blank", async ({ page }) => {
+test("username is blank should display error", async ({ page }) => {
   await page.getByLabel("Username").clear()
   await page.getByRole("button", { name: "Create Account" }).click()
   await expect(page.getByText("Username is required")).toBeVisible()
 })
 
-test("should display error when username is more than 255 characters", async ({
+test("username is more than 255 characters should display error", async ({
   page,
 }) => {
   const username = "a".repeat(256)
@@ -84,7 +84,7 @@ test("should display error when username is more than 255 characters", async ({
   ).not.toBeVisible()
 })
 
-test("should display root error message when submission fails with rate limit exception", async ({
+test("submission fails with rate limit exception should display root error message", async ({
   page,
 }) => {
   const timeoutInSeconds = 30
@@ -99,4 +99,27 @@ test("should display root error message when submission fails with rate limit ex
       `Rate Limit Exceeded, please try again after ${timeoutInSeconds} seconds`
     )
   ).toBeVisible()
+})
+
+test("password is blank should display password error", async ({ page }) => {
+  await page.getByLabel("Password", { exact: true }).clear()
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(page.getByText("Password is required")).toBeVisible()
+})
+
+test("invalid password min length should display password error", async ({
+  page,
+}) => {
+  const password = "1234567"
+  await page.getByLabel("Password", { exact: true }).fill(password)
+  await page.getByRole("button", { name: "Create Account" }).click()
+  await expect(
+    page.getByText("Password needs to have min length of 8 characters")
+  ).toBeVisible()
+
+  await page.getByLabel("Password", { exact: true }).clear()
+  await page.getByLabel("Password", { exact: true }).fill("12345678")
+  await expect(
+    page.getByText("Password needs to have min length of 8 characters")
+  ).not.toBeVisible()
 })

--- a/frontend/__tests__/account.spec.ts
+++ b/frontend/__tests__/account.spec.ts
@@ -177,7 +177,11 @@ test("login with rate limit exceeded shows error message", async ({ page }) => {
   await expect(page.getByRole("heading", { name: "Login" })).toBeVisible()
 })
 
-// test("should create a new account", async ({ page }) => {
-//  await navigateToLoginPage(page)
-//   // TODO create new account, login page => create new account link => submit form => redirect to login page
-// })
+test("should navigate to create new account page from login page", async ({
+  page,
+}) => {
+  await navigateToLoginPage(page)
+  expect(page.url()).toContain("/login")
+  await page.getByRole("link", { name: "Register" }).click()
+  expect(page.url()).toContain("/register")
+})

--- a/frontend/src/components/CreateAccountForm.css
+++ b/frontend/src/components/CreateAccountForm.css
@@ -1,0 +1,23 @@
+#create-account-form {
+  display: flex;
+  flex-direction: column;
+  row-gap: 0.4rem;
+  width: 100%;
+  max-width: 70ch;
+}
+
+#create-account-form input {
+  font-size: 1rem;
+  padding: 0.2em;
+}
+
+#create-account-form button[type="submit"] {
+  margin-top: 1rem;
+  padding: 1rem;
+  border-radius: 8px;
+  background-color: #0ea5e9;
+  color: white;
+}
+#create-account-form button[type="submit"]:hover {
+  background-color: #0284c7;
+}

--- a/frontend/src/components/CreateAccountForm.tsx
+++ b/frontend/src/components/CreateAccountForm.tsx
@@ -14,6 +14,7 @@ type FormFields = {
 function CreateAccountForm({ handleCreateAccount }: CreateAccountProps) {
   const {
     register,
+    getValues,
     handleSubmit,
     setError,
     formState: { errors, isSubmitting },
@@ -72,8 +73,22 @@ function CreateAccountForm({ handleCreateAccount }: CreateAccountProps) {
       <input
         id="confirm-password"
         type="password"
-        {...register("confirmPassword")}
+        {...register("confirmPassword", {
+          required: "Confirm Password is required",
+          validate: {
+            matchesPassword: (v) =>
+              v === getValues("password") ||
+              "Password and Confirm Password needs to match",
+          },
+        })}
       />
+      {errors.confirmPassword && (
+        <div>
+          <p role="alert" className="error-text">
+            {errors.confirmPassword.message}
+          </p>
+        </div>
+      )}
 
       {errors.root && (
         <div>

--- a/frontend/src/components/CreateAccountForm.tsx
+++ b/frontend/src/components/CreateAccountForm.tsx
@@ -50,8 +50,24 @@ function CreateAccountForm({ handleCreateAccount }: CreateAccountProps) {
         </div>
       )}
       <label htmlFor="password">Password</label>
-      <input id="password" type="password" {...register("password")} />
-
+      <input
+        id="password"
+        type="password"
+        {...register("password", {
+          required: "Password is required",
+          minLength: {
+            value: 8,
+            message: "Password needs to have min length of 8 characters",
+          },
+        })}
+      />
+      {errors.password && (
+        <div>
+          <p role="alert" className="error-text">
+            {errors.password.message}
+          </p>
+        </div>
+      )}
       <label htmlFor="confirm-password">Confirm Password</label>
       <input
         id="confirm-password"

--- a/frontend/src/components/CreateAccountForm.tsx
+++ b/frontend/src/components/CreateAccountForm.tsx
@@ -15,21 +15,40 @@ function CreateAccountForm({ handleCreateAccount }: CreateAccountProps) {
   const {
     register,
     handleSubmit,
-    formState: { isSubmitting },
+    setError,
+    formState: { errors, isSubmitting },
   } = useForm<FormFields>()
   const onSubmit: SubmitHandler<FormFields> = async (data) => {
     try {
       await handleCreateAccount(data.username, data.password)
-    } catch (error) {
-      // TODO display error in form
-      console.error(error)
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } catch (error: any) {
+      setError("root", {
+        message: error.message,
+      })
     }
   }
   return (
     <form id="create-account-form" onSubmit={handleSubmit(onSubmit)}>
       <label htmlFor="username">Username</label>
-      <input id="username" type="text" {...register("username")} />
-
+      <input
+        id="username"
+        type="text"
+        {...register("username", {
+          required: "Username is required",
+          maxLength: {
+            value: 255,
+            message: "Username cannot be longer than 255 characters",
+          },
+        })}
+      />
+      {errors.username && (
+        <div>
+          <p role="alert" className="error-text">
+            {errors.username.message}
+          </p>
+        </div>
+      )}
       <label htmlFor="password">Password</label>
       <input id="password" type="password" {...register("password")} />
 
@@ -39,6 +58,14 @@ function CreateAccountForm({ handleCreateAccount }: CreateAccountProps) {
         type="password"
         {...register("confirmPassword")}
       />
+
+      {errors.root && (
+        <div>
+          <p role="alert" className="error-text">
+            {errors.root.message}
+          </p>
+        </div>
+      )}
       <button type="submit" disabled={isSubmitting}>
         Create Account
       </button>

--- a/frontend/src/components/CreateAccountForm.tsx
+++ b/frontend/src/components/CreateAccountForm.tsx
@@ -1,0 +1,49 @@
+import { SubmitHandler, useForm } from "react-hook-form"
+import "./CreateAccountForm.css"
+
+type CreateAccountProps = {
+  handleCreateAccount: (username: string, password: string) => Promise<void>
+}
+
+type FormFields = {
+  username: string
+  password: string
+  confirmPassword: string
+}
+
+function CreateAccountForm({ handleCreateAccount }: CreateAccountProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm<FormFields>()
+  const onSubmit: SubmitHandler<FormFields> = async (data) => {
+    try {
+      await handleCreateAccount(data.username, data.password)
+    } catch (error) {
+      // TODO display error in form
+      console.error(error)
+    }
+  }
+  return (
+    <form id="create-account-form" onSubmit={handleSubmit(onSubmit)}>
+      <label htmlFor="username">Username</label>
+      <input id="username" type="text" {...register("username")} />
+
+      <label htmlFor="password">Password</label>
+      <input id="password" type="password" {...register("password")} />
+
+      <label htmlFor="confirm-password">Confirm Password</label>
+      <input
+        id="confirm-password"
+        type="password"
+        {...register("confirmPassword")}
+      />
+      <button type="submit" disabled={isSubmitting}>
+        Create Account
+      </button>
+    </form>
+  )
+}
+
+export default CreateAccountForm

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -10,6 +10,7 @@ import UrlStatsPage from "./pages/UrlStatsPage.tsx"
 import LoginPage from "./pages/LoginPage.tsx"
 import LogoutPage from "./pages/LogoutPage.tsx"
 import AuthProvider from "./hooks/AuthProvider.tsx"
+import CreateAccountPage from "./pages/CreateAccountPage.tsx"
 
 const router = createBrowserRouter([
   {
@@ -48,6 +49,11 @@ const router = createBrowserRouter([
       {
         path: "/logout",
         element: <LogoutPage />,
+        errorElement: <NotFoundPage errorMessage="404 Not Found" />,
+      },
+      {
+        path: "/register",
+        element: <CreateAccountPage />,
         errorElement: <NotFoundPage errorMessage="404 Not Found" />,
       },
     ],

--- a/frontend/src/pages/CreateAccountPage.tsx
+++ b/frontend/src/pages/CreateAccountPage.tsx
@@ -1,0 +1,28 @@
+import { useRef } from "react"
+import CreateAccountForm from "../components/CreateAccountForm"
+import Footer from "../components/Footer"
+import Header from "../components/Header"
+import { createAccount } from "../endpoints/user"
+import { useNavigate } from "react-router-dom"
+
+function CreateAccountPage() {
+  const navigate = useNavigate()
+  const abortControllerRef = useRef<AbortController | null>(null)
+
+  async function handleCreateAccount(username: string, password: string) {
+    abortControllerRef.current?.abort()
+    abortControllerRef.current = new AbortController()
+    await createAccount(username, password, abortControllerRef.current)
+    navigate("/login")
+  }
+  return (
+    <>
+      <Header />
+      <h2>Create a new account</h2>
+      <CreateAccountForm handleCreateAccount={handleCreateAccount} />
+      <Footer />
+    </>
+  )
+}
+
+export default CreateAccountPage

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom"
 import Footer from "../components/Footer"
 import Header from "../components/Header"
 import LoginForm from "../components/LoginForm"
@@ -16,7 +17,12 @@ function LoginPage() {
       <Header />
       <h2>Login</h2>
       <LoginForm handleLogin={handleLogin} />
-      <p>Don't have an account? Register</p>
+      <p>
+        Don't have an account?{" "}
+        <Link to="/register" data-testid="loginPage-register-link">
+          Register
+        </Link>
+      </p>
       <Footer />
     </>
   )


### PR DESCRIPTION
### Tasks
- [x] Add create new account page on route `/register`
- [x] Create backend api call to create new account, have AbortController to prevent duplicate requests
- [x] Create new account form, redirect user to `/login` route after successful create new account
- [x] Add create new account form validations and error messages
    - [x] Ensure password is min 8 chars, not empty
    - [x] Ensure username is not empty (max of 255 chars)
    - [x] Ensure confirm password matches the password - https://stackoverflow.com/questions/63096634/check-two-textfield-have-the-same-value-with-react-hook-form
    - [x] Add "root" error validation (e.g. when endpoint returns HTTP 429 error)