### PR TITLE
Move backend cors middleware to before json request middleware

### DIFF
--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,5 +1,3 @@
-import "dotenv/config"
-import cors from "cors"
 import startCronJobs from "./cron/index.js"
 import pool, { populateMaliciousFeeds, setupDatabase } from "./database.js"
 import setupApp from "./server.js"
@@ -9,15 +7,6 @@ const PORT = 3000
 
 async function startBackend() {
   const app = await setupApp()
-  if (process.env.ENV === "PROD") {
-    app.use(
-      cors({
-        origin: process.env.FRONTEND_ORIGIN, // Access-Control-Allow-Origin, allow only frontend origin
-        methods: ["GET", "POST", "PUT", "DELETE"],
-        credentials: true, // Access-Control-Allow-Credentials for cookies
-      })
-    )
-  }
   app.listen(PORT, () => {
     console.log(`Server started on port ${PORT}`)
     app.emit("serverStarted")

--- a/backend/server.ts
+++ b/backend/server.ts
@@ -1,4 +1,5 @@
 import "dotenv/config"
+import cors from "cors"
 import express from "express"
 import session from "express-session"
 import connectPgSimple from "connect-pg-simple"
@@ -15,6 +16,16 @@ async function setupApp() {
   const app = express()
   // https://github.com/express-rate-limit/express-rate-limit/wiki/Troubleshooting-Proxy-Issues
   app.set("trust proxy", 1) // Trust first proxy (reverse proxy)
+  if (process.env.ENV === "PROD") {
+    // https://stackoverflow.com/questions/71948888/cors-why-do-i-get-successful-preflight-options-but-still-get-cors-error-with-p
+    app.use(
+      cors({
+        origin: process.env.FRONTEND_ORIGIN, // Access-Control-Allow-Origin, allow only frontend origin
+        methods: ["GET", "POST", "PUT", "DELETE"],
+        credentials: true, // Access-Control-Allow-Credentials for cookies
+      })
+    )
+  }
   const pgSession = connectPgSimple(session)
   app.use(
     session({


### PR DESCRIPTION
Move your cors() middleware before express.json() and you won't have a CORS issue any more. The problem was due to an error in the express.json() middleware killing the request before CORS headers were added 

https://stackoverflow.com/questions/71948888/cors-why-do-i-get-successful-preflight-options-but-still-get-cors-error-with-p

... has been blocked by CORS policy: Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.