### PR TITLE
Fix backend flaky tests and update urls table to include user as foreign key

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -92,6 +92,7 @@ Column naming convention (lowercase with underscores)
 14. Passport js always returning 500 internal error - https://stackoverflow.com/questions/29580522/passport-js-always-returning-500-internal-error
 15. node-postgres: how to execute "WHERE col IN (<dynamic value list>)" query? - https://stackoverflow.com/questions/10720420/node-postgres-how-to-execute-where-col-in-dynamic-value-list-query
 16. For url LIKE query matching https://www.postgresql.org/docs/current/indexes-opclass.html - https://stackoverflow.com/questions/1566717/postgresql-like-query-performance-variations/13452528#13452528
+17. Foreign Key cannot be defined as SERIAL. Use INTEGER type instead (e.g. BIGINT to replace foreign key of BIGSERIAL)!! - https://stackoverflow.com/questions/28558920/postgresql-foreign-key-syntax
 
 # References (Testing)
 

--- a/backend/__tests__/routes/auth.test.ts
+++ b/backend/__tests__/routes/auth.test.ts
@@ -18,6 +18,7 @@ function getMockMiddleware() {
 
 describe("Auth API", () => {
   let app: Express
+  let usernames: string[] = []
 
   beforeAll(async () => {
     app = await setupApp()
@@ -25,7 +26,8 @@ describe("Auth API", () => {
   })
 
   beforeEach(async () => {
-    await pool.query("DELETE FROM users")
+    await pool.query("DELETE FROM users WHERE username = ANY($1)", [usernames])
+    usernames = []
     vi.mock("../../middleware/rateLimiter.js", () => {
       return {
         default: {
@@ -44,7 +46,7 @@ describe("Auth API", () => {
   })
 
   afterEach(async () => {
-    await pool.query("DELETE FROM users")
+    await pool.query("DELETE FROM users WHERE username = ANY($1)", [usernames])
     vi.restoreAllMocks()
   })
 
@@ -55,7 +57,9 @@ describe("Auth API", () => {
     })
 
     test("should accept login with account that exists with correct credentials", async () => {
-      const username = "test_username00"
+      const username = "auth.test.ts_test_username00"
+      usernames.push(username)
+
       const password = "12345678"
       const createAccountResponse = await request(app)
         .post("/api/auth/users")
@@ -77,7 +81,9 @@ describe("Auth API", () => {
     })
 
     test("should reject login with account with incorrect credentials", async () => {
-      const username = "test_username0"
+      const username = "auth.test.ts_test_username01"
+      usernames.push(username)
+
       const password = "12345678"
       const incorrectPassword = "incorrectPassword"
       const createAccountResponse = await request(app)
@@ -94,7 +100,9 @@ describe("Auth API", () => {
     })
 
     test("should reject login with account with missing password", async () => {
-      const username = "test_username2"
+      const username = "auth.test.ts_test_username02"
+      usernames.push(username)
+
       const password = "12345678"
       const createAccountResponse = await request(app)
         .post("/api/auth/users")
@@ -129,7 +137,9 @@ describe("Auth API", () => {
   describe("POST /api/auth/logout", () => {
     // https://github.com/ladjs/supertest/issues/665
     test("should logout user that is currently logged in", async () => {
-      const username = "test_username"
+      const username = "auth.test.ts_test_username04"
+      usernames.push(username)
+
       const password = "12345678"
       const createAccountResponse = await request(app)
         .post("/api/auth/users")
@@ -158,7 +168,9 @@ describe("Auth API", () => {
 
   describe("POST /api/auth/users", () => {
     test("should create new account with username that does not exist", async () => {
-      const username = "test_username"
+      const username = "auth.test.ts_test_username90"
+      usernames.push(username)
+
       const password = "12345678"
       const createAccountResponse = await request(app)
         .post("/api/auth/users")
@@ -167,7 +179,9 @@ describe("Auth API", () => {
     })
 
     test("should not create account with username that already exists", async () => {
-      const username = "test_username"
+      const username = "auth.test.ts_test_username560"
+      usernames.push(username)
+
       const password = "12345678"
       const createAccountResponse = await request(app)
         .post("/api/auth/users")
@@ -188,7 +202,9 @@ describe("Auth API", () => {
 
   describe("GET /api/auth/status", () => {
     test("should receive user auth status of HTTP 200 based on given valid cookie", async () => {
-      const username = "test_username"
+      const username = "auth.test.ts_test_username030"
+      usernames.push(username)
+
       const password = "123456789"
       const createAccountResponse = await request(app)
         .post("/api/auth/users")

--- a/backend/__tests__/routes/malicious.test.ts
+++ b/backend/__tests__/routes/malicious.test.ts
@@ -30,7 +30,6 @@ describe("Malicious API to check urls", () => {
 
   beforeEach(async () => {
     maliciousUrls = []
-    await pool.query("DELETE FROM users")
     vi.mock("../../middleware/rateLimiter.js", () => {
       return {
         default: {
@@ -50,7 +49,6 @@ describe("Malicious API to check urls", () => {
   })
 
   afterEach(async () => {
-    await pool.query("DELETE FROM users")
     vi.restoreAllMocks()
     maliciousUrls.forEach(async (url) => await removeMockMaliciousUrl(url))
   })

--- a/backend/database.ts
+++ b/backend/database.ts
@@ -25,24 +25,27 @@ async function setupDatabase(pool: pg.Pool) {
       url VARCHAR(2048) UNIQUE NOT NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )`)
+    await pool.query(`CREATE TABLE IF NOT EXISTS "users" (
+      id BIGSERIAL PRIMARY KEY,
+      username VARCHAR(255) UNIQUE NOT NULL,
+      hashed_password TEXT NOT NULL,
+      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+    )`)
+    // one to many table between user => url(s). Foreign key should be INTEGER instead of SERIAL
     await pool.query(`CREATE TABLE IF NOT EXISTS "urls" (
       id BIGSERIAL PRIMARY KEY,
+      user_id BIGINT DEFAULT NULL,
       url VARCHAR(2048) NOT NULL,
       short_code CHAR(7) UNIQUE NOT NULL,
       created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-      updated_at TIMESTAMPTZ
+      updated_at TIMESTAMPTZ,
+      FOREIGN KEY (user_id) REFERENCES "users" (id)
     )`)
     await pool.query(`CREATE TABLE IF NOT EXISTS "stats" (
       id BIGSERIAL PRIMARY KEY,
       url_id BIGSERIAL,
       access_count INTEGER NOT NULL DEFAULT 0,
       FOREIGN KEY (url_id) REFERENCES "urls"(id)
-    )`)
-    await pool.query(`CREATE TABLE IF NOT EXISTS "users" (
-      id BIGSERIAL PRIMARY KEY,
-      username VARCHAR(255) UNIQUE NOT NULL,
-      hashed_password TEXT NOT NULL,
-      created_at TIMESTAMPTZ NOT NULL DEFAULT now()
     )`)
     await setupIndexes(pool)
   } catch (error) {}


### PR DESCRIPTION
Flaky backend test was due to beforeEach and afterEach `DELETE FROM users` query. Vitest runs tests in parallel. Some other test was depending on a created user, but it was deleted as part of some other tests' beforeEach / afterEach!

Update urls table to have foreign key reference of a possible user. User => one or many urls (one to many relationship)